### PR TITLE
fix: initial grid does not match initial grid in tests file

### DIFF
--- a/004/zombie_outbreak_sim.py
+++ b/004/zombie_outbreak_sim.py
@@ -70,8 +70,8 @@ def simulate_zombie_outbreak(city, days):
 # Example usage
 initial_grid = [
     ["H", "H", "H", "Z"],
-    ["H", "H", "H", "E"],
-    ["H", "E", "H", "H"],
+    ["H", "H", "E", "H"],
+    ["H", "H", "H", "H"],
     ["H", "H", "H", "H"],
 ]
 


### PR DESCRIPTION
The supplied tests always fail since the supplied starting grid does not match that in the test file. This change makes them the same.